### PR TITLE
修正关于yobot作为源码版时的路径问题

### DIFF
--- a/yocool.py
+++ b/yocool.py
@@ -17,7 +17,7 @@ except:
     path = os.path.dirname(__file__)
 
 try:
-    yobot_path  = config.path
+    yobot_path  = config.yobot_path
 except:
     yobot_path = './hoshino/modules/yobot/yobot/'
 


### PR DESCRIPTION
yobot作为源码版运行时安装主题出现如图的错误

![](https://img.rruu.net/image/60162923a63de)

发现它在找yobot文件时路径出现了找不到的情况，确认了下config里的路径没有写错，翻了下源文件，看见yobot_path疑似被错误赋值为 config.path(配置文件里说这是yocool目录路径)，而不是config.yobot_path(配置文件里说这是yobot目录路径)，将config.path改成config.yobot_path即安装成功。